### PR TITLE
Corrected issue preventing empty suites sending reports

### DIFF
--- a/core/runner/src/lib.rs
+++ b/core/runner/src/lib.rs
@@ -157,7 +157,13 @@ impl<
             ComponentRunResult::AlreadyPublished(report_builder) => {
                 ComponentRunResult::AlreadyPublished(report_builder.build())
             }
-            ComponentRunResult::WaitingOnChildren => ComponentRunResult::WaitingOnChildren,
+            ComponentRunResult::WaitingOnChildren => {
+                // A Suite will wait on children before its results can be 
+                // determined, if all the children are ignored or there are no
+                // children then the assume a pass results
+                component_state.tentative_pass();              
+                ComponentRunResult::WaitingOnChildren
+            },
         }
     }
 

--- a/examples/1_setup_test_teardown/a_test_basics/Cargo.toml
+++ b/examples/1_setup_test_teardown/a_test_basics/Cargo.toml
@@ -7,10 +7,8 @@ edition = "2018"
 async-std = { version = "1.10.0", optional = true}
 tokio = { version = "1.15.0",  features = ["time"], optional = true}
 
-#integra8 = {path = "../../../core/integra8"}
-#integra8_tree_formatter = {path = "../../../contrib/formatters/tree_formatter" }
-integra8 = "0.0.1-alpha"
-integra8_tree_formatter = "0.0.1-alpha"
+integra8 = {path = "../../../core/integra8"}
+integra8_tree_formatter = {path = "../../../contrib/formatters/tree_formatter" }
 
 [features]
 async-std-runtime = ["async-std"]

--- a/examples/validate_examples/src/main.rs
+++ b/examples/validate_examples/src/main.rs
@@ -5,8 +5,9 @@
 pub extern crate integra8;
 
 main_test! {
-    // TODO: this should be automatically detected as default
     max_concurrency: Auto, // [Auto, 1, any]
+
+    // TODO: this should be automatically detected as default
     console_output: integra8_tree_formatter::TreeFormatter,
     //console_output_ansi_mode: Auto,
     //console_output_level: Error,
@@ -75,13 +76,9 @@ macro_rules! assert_test_fails {
 #[suite]
 mod basic_examples {
 
-    // Somehow this got very broken
-    // TODO: fix this 
-    #[allow_fail] 
     #[integration_test]
     async fn test_basics(ctx : crate::ExecutionContext) {
         assert_test_passes!("./test_basics", ctx);
-
     }
 
     #[integration_test]


### PR DESCRIPTION
**Fixes the following use cases:

1. Suite without any components:**
2. Suite without only ignored components**
3. Suites where the first component to execute is ignored 

Expected behaviour for all: 
| Suite has a passed result.

Observed behaviour:
| Suite is never reported as completing ​or, if it is the root suite, output formatter will panic when it cant find a root.